### PR TITLE
Changing team resource to edit team name instead of recreate

### DIFF
--- a/builtin/providers/github/resource_github_team.go
+++ b/builtin/providers/github/resource_github_team.go
@@ -17,7 +17,6 @@ func resourceGithubTeam() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
@@ -63,8 +62,10 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	name := d.Get("name").(string)
 	description := d.Get("description").(string)
 	team.Description = &description
+	team.Name = &name
 
 	team, _, err = client.Organizations.EditTeam(*team.ID, team)
 	if err != nil {

--- a/builtin/providers/github/resource_github_team.go
+++ b/builtin/providers/github/resource_github_team.go
@@ -50,6 +50,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	d.Set("description", team.Description)
+	d.Set("name", team.Name)
 	return nil
 }
 

--- a/builtin/providers/github/resource_github_team_test.go
+++ b/builtin/providers/github/resource_github_team_test.go
@@ -21,14 +21,14 @@ func TestAccGithubTeam_basic(t *testing.T) {
 				Config: testAccGithubTeamConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamExists("github_team.foo", &team),
-					testAccCheckGithubTeamAttributes(&team, "Terraform acc test group"),
+					testAccCheckGithubTeamAttributes(&team, "foo", "Terraform acc test group"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccGithubTeamUpdateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamExists("github_team.foo", &team),
-					testAccCheckGithubTeamAttributes(&team, "Terraform acc test group - updated"),
+					testAccCheckGithubTeamAttributes(&team, "foo2", "Terraform acc test group - updated"),
 				),
 			},
 		},
@@ -56,8 +56,12 @@ func testAccCheckGithubTeamExists(n string, team *github.Team) resource.TestChec
 	}
 }
 
-func testAccCheckGithubTeamAttributes(team *github.Team, description string) resource.TestCheckFunc {
+func testAccCheckGithubTeamAttributes(team *github.Team, name, description string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		if *team.Name != name {
+			return fmt.Errorf("Team name does not match: %s, %s", *team.Name, name)
+		}
+
 		if *team.Description != description {
 			return fmt.Errorf("Team description does not match: %s, %s", *team.Description, description)
 		}
@@ -98,7 +102,7 @@ resource "github_team" "foo" {
 
 const testAccGithubTeamUpdateConfig = `
 resource "github_team" "foo" {
-	name = "foo"
+	name = "foo2"
 	description = "Terraform acc test group - updated"
 }
 `


### PR DESCRIPTION
This works as expected. Built and tried it as well to make sure.
