### PR TITLE
Adding the github_team_membership resource for #2

### DIFF
--- a/builtin/providers/github/resource_github_membership.go
+++ b/builtin/providers/github/resource_github_membership.go
@@ -1,10 +1,8 @@
 package github
 
 import (
-	"fmt"
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
 )
 
 func resourceGithubMembership() *schema.Resource {
@@ -41,7 +39,7 @@ func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(buildMembershipId(membership.Organization.Login, membership.User.Login))
+	d.SetId(buildTwoPartId(membership.Organization.Login, membership.User.Login))
 
 	return resourceGithubMembershipRead(d, meta)
 }
@@ -83,15 +81,4 @@ func resourceGithubMembershipDelete(d *schema.ResourceData, meta interface{}) er
 	_, err := client.Organizations.RemoveOrgMembership(n, meta.(*GithubClient).organization)
 
 	return err
-}
-
-// return the pieces of the id as org, user
-func parseMembershipId(id string) (string, string) {
-	parts := strings.SplitN(id, ":", 2)
-	return parts[0], parts[1]
-}
-
-// Since there is no id for memberships, we are storing in form organization:user
-func buildMembershipId(org, user *string) string {
-	return fmt.Sprintf("%s:%s", *org, *user)
 }

--- a/builtin/providers/github/resource_github_membership.go
+++ b/builtin/providers/github/resource_github_membership.go
@@ -21,8 +21,9 @@ func resourceGithubMembership() *schema.Resource {
 			},
 			"role": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validateRoleValueFunc([]string{"member", "admin"}),
+				Default:      "member",
 			},
 		},
 	}

--- a/builtin/providers/github/resource_github_membership_test.go
+++ b/builtin/providers/github/resource_github_membership_test.go
@@ -34,13 +34,13 @@ func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
 		if rs.Type != "github_membership" {
 			continue
 		}
-		o, u := parseMembershipId(rs.Primary.ID)
+		o, u := parseTwoPartId(rs.Primary.ID)
 
 		membership, resp, err := conn.Organizations.GetOrgMembership(u, o)
 
 		if err == nil {
 			if membership != nil &&
-				buildMembershipId(membership.Organization.Login, membership.User.Login) == rs.Primary.ID {
+				buildTwoPartId(membership.Organization.Login, membership.User.Login) == rs.Primary.ID {
 				return fmt.Errorf("Organization membership still exists")
 			}
 		}
@@ -64,7 +64,7 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 		}
 
 		conn := testAccProvider.Meta().(*GithubClient).client
-		o, u := parseMembershipId(rs.Primary.ID)
+		o, u := parseTwoPartId(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(u, o)
 		if err != nil {
@@ -87,7 +87,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 		}
 
 		conn := testAccProvider.Meta().(*GithubClient).client
-		o, u := parseMembershipId(rs.Primary.ID)
+		o, u := parseTwoPartId(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(u, o)
 		if err != nil {

--- a/builtin/providers/github/resource_github_team_membership.go
+++ b/builtin/providers/github/resource_github_team_membership.go
@@ -1,7 +1,9 @@
 package github
 
 import (
+	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
 )
 
 func resourceGithubTeamMembership() *schema.Resource {
@@ -9,7 +11,7 @@ func resourceGithubTeamMembership() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGithubTeamMembershipCreate,
 		Read:   resourceGithubTeamMembershipRead,
-		Update: resourceGithubTeamMembershipUpdate,
+		// editing team memberships are not supported by github api so forcing new on any changes
 		Delete: resourceGithubTeamMembershipDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -24,28 +26,74 @@ func resourceGithubTeamMembership() *schema.Resource {
 				ForceNew: true,
 			},
 			"role": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "member",
-				//TODO validate function (member, maintainer)
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "member",
+				ValidateFunc: validateRoleValueFunc([]string{"member", "maintainer"}),
 			},
 		},
 	}
 }
 
 func resourceGithubTeamMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	//TODO the ID to store in the state file needs to be team_id:username
-	return nil
+	client := meta.(*GithubClient).client
+	t := d.Get("team_id").(string)
+	n := d.Get("username").(string)
+	r := d.Get("role").(string)
+
+	_, _, err := client.Organizations.AddTeamMembership(toGithubId(t), n,
+		&github.OrganizationAddTeamMembershipOptions{Role: r})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildTwoPartId(&t, &n))
+
+	return resourceGithubTeamMembershipRead(d, meta)
 }
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
+	client := meta.(*GithubClient).client
+	t := d.Get("team_id").(string)
+	n := d.Get("username").(string)
 
-func resourceGithubTeamMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
+	membership, _, err := client.Organizations.GetTeamMembership(toGithubId(t), n)
+
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+	team, user := getTeamAndUserFromUrl(membership.URL)
+
+	d.Set("username", user)
+	d.Set("role", membership.Role)
+	d.Set("team_id", team)
 	return nil
 }
 
 func resourceGithubTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	client := meta.(*GithubClient).client
+	t := d.Get("team_id").(string)
+	n := d.Get("username").(string)
+
+	_, err := client.Organizations.RemoveTeamMembership(toGithubId(t), n)
+
+	return err
+}
+
+func getTeamAndUserFromUrl(url *string) (string, string) {
+	var team, user string
+
+	urlSlice := strings.Split(*url, "/")
+	for v := range urlSlice {
+		if urlSlice[v] == "teams" {
+			team = urlSlice[v+1]
+		}
+		if urlSlice[v] == "memberships" {
+			user = urlSlice[v+1]
+		}
+	}
+	return team, user
 }

--- a/builtin/providers/github/resource_github_team_membership_test.go
+++ b/builtin/providers/github/resource_github_team_membership_test.go
@@ -1,0 +1,122 @@
+package github
+
+import (
+	"fmt"
+	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestAccGithubTeamMembership_basic(t *testing.T) {
+	var membership github.Membership
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubTeamMembershipConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubTeamMembershipExists("github_team_membership.test_team_membership", &membership),
+					testAccCheckGithubTeamMembershipRoleState("github_team_membership.test_team_membership", &membership),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*GithubClient).client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "github_team_membership" {
+			continue
+		}
+
+		t, u := parseTwoPartId(rs.Primary.ID)
+		membership, resp, err := conn.Organizations.GetTeamMembership(toGithubId(t), u)
+		if err == nil {
+			if membership != nil {
+				return fmt.Errorf("Team membership still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccCheckGithubTeamMembershipExists(n string, membership *github.Membership) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No team membership ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*GithubClient).client
+		t, u := parseTwoPartId(rs.Primary.ID)
+
+		teamMembership, _, err := conn.Organizations.GetTeamMembership(toGithubId(t), u)
+
+		if err != nil {
+			return err
+		}
+		*membership = *teamMembership
+		return nil
+	}
+}
+
+func testAccCheckGithubTeamMembershipRoleState(n string, membership *github.Membership) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No team membership ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*GithubClient).client
+		t, u := parseTwoPartId(rs.Primary.ID)
+
+		teamMembership, _, err := conn.Organizations.GetTeamMembership(toGithubId(t), u)
+		if err != nil {
+			return err
+		}
+
+		resourceRole := membership.Role
+		actualRole := teamMembership.Role
+
+		if *resourceRole != *actualRole {
+			return fmt.Errorf("Team membership role %v in resource does match actual state of %v", *resourceRole, *actualRole)
+		}
+		return nil
+	}
+}
+
+const testAccGithubTeamMembershipConfig = `
+resource "github_membership" "test_org_membership" {
+	username = "TerraformDummyUser"
+	role = "member"
+}
+
+resource "github_team" "test_team" {
+	name = "foo"
+	description = "Terraform acc test group"
+}
+
+resource "github_team_membership" "test_team_membership" {
+	team_id = "${github_team.test_team.id}"
+	username = "TerraformDummyUser"
+	role = "member"
+}
+`

--- a/builtin/providers/github/util.go
+++ b/builtin/providers/github/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"strconv"
+	"strings"
 )
 
 func toGithubId(id string) int {
@@ -31,4 +32,15 @@ func validateRoleValueFunc(roles []string) schema.SchemaValidateFunc {
 		}
 		return
 	}
+}
+
+// return the pieces of id `a:b` as a, b
+func parseTwoPartId(id string) (string, string) {
+	parts := strings.SplitN(id, ":", 2)
+	return parts[0], parts[1]
+}
+
+// format the strings into an id `a:b`
+func buildTwoPartId(a, b *string) string {
+	return fmt.Sprintf("%s:%s", *a, *b)
 }

--- a/builtin/providers/github/util_test.go
+++ b/builtin/providers/github/util_test.go
@@ -33,3 +33,23 @@ func TestAccGithubUtilRole_validation(t *testing.T) {
 		}
 	}
 }
+
+func TestAccGithubUtilTwoPartId(t *testing.T) {
+	partOne, partTwo := "foo", "bar"
+
+	id := buildTwoPartId(&partOne, &partTwo)
+
+	if id != "foo:bar" {
+		t.Fatalf("Expected two part id to be foo:bar, actual: %s", id)
+	}
+
+	parsedPartOne, parsedPartTwo := parseTwoPartId(id)
+
+	if parsedPartOne != "foo" {
+		t.Fatalf("Expected parsed part one foo, actual: %s", parsedPartOne)
+	}
+
+	if parsedPartTwo != "bar" {
+		t.Fatalf("Expected parsed part two bar, actual: %s", parsedPartTwo)
+	}
+}

--- a/website/source/docs/providers/github/r/membership.html.markdown
+++ b/website/source/docs/providers/github/r/membership.html.markdown
@@ -29,5 +29,5 @@ resource "github_membership" "membership_for_some_user" {
 The following arguments are supported:
 
 * `username` - (Required) The user to add to the organization.
-* `role` - (Required) The role of the user within the organization. 
-            Must be one of `member` or `admin`.
+* `role` - (Optional) The role of the user within the organization. 
+            Must be one of `member` or `admin`. Defaults to `member`.

--- a/website/source/docs/providers/github/r/team_membership.html.markdown
+++ b/website/source/docs/providers/github/r/team_membership.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "github"
+page_title: "Github: github_team_membership"
+sidebar_current: "docs-github-resource-team-membership"
+description: |-
+  Provides a Github team membership resource.
+---
+
+# github\_team_membership
+
+Provides a Github team membership resource.
+
+This resource allows you to add/remove users from teams in your organization. When applied,
+the user will be added to the team. If the user hasn't accepted their invitation to the 
+organization, they won't be part of the team until they do. When
+destroyed, the user will be removed from the team.
+
+## Example Usage
+
+```
+# Add a user to the organization
+resource "github_membership" "membership_for_some_user" {
+    username = "SomeUser"
+    role = "member"
+}
+
+resource "github_team" "some_team" {
+	name = "SomeTeam"
+	description = "Some cool team"
+}
+
+resource "github_team_membership" "some_team_membership" {
+	team_id = "${github_team.some_team.id}"
+	username = "SomeUser"
+	role = "member"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) The Github team id
+* `username` - (Required) The user to add to the organization.
+* `role` - (Required) The role of the user within the team. 
+            Must be one of `member` or `maintainer`.

--- a/website/source/docs/providers/github/r/team_membership.html.markdown
+++ b/website/source/docs/providers/github/r/team_membership.html.markdown
@@ -41,6 +41,6 @@ resource "github_team_membership" "some_team_membership" {
 The following arguments are supported:
 
 * `team_id` - (Required) The Github team id
-* `username` - (Required) The user to add to the organization.
-* `role` - (Required) The role of the user within the team. 
-            Must be one of `member` or `maintainer`.
+* `username` - (Required) The user to add to the team.
+* `role` - (Optional) The role of the user within the team. 
+            Must be one of `member` or `maintainer`. Defaults to `member`.

--- a/website/source/layouts/github.erb
+++ b/website/source/layouts/github.erb
@@ -16,6 +16,9 @@
 					<li<%= sidebar_current("docs-github-resource-membership") %>>
 					<a href="/docs/providers/github/r/membership.html">github_membership</a>
 					</li>
+					<li<%= sidebar_current("docs-github-resource-team-membership") %>>
+                    <a href="/docs/providers/github/r/team_membership.html">github_team_membership</a>
+                    </li>
 				</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
This commit adds a resource that controls membership for
teams within organizations.
- Implemented the resource
- Added acceptance testing
- Added a page to the Terraform website for the resource
